### PR TITLE
Update all tabs on first load

### DIFF
--- a/background.js
+++ b/background.js
@@ -49,6 +49,11 @@ function scanPage(tab) {
 	}
 }
 
+function refreshAllTabsPageAction() {
+	browser.tabs.query({}).then(scanTabs).catch(console.error);
+}
+
 browser.runtime.onMessage.addListener(messageHandler);
 browser.tabs.onUpdated.addListener(scanPage);
 browser.tabs.onRemoved.addListener(removeHandler);
+refreshAllTabsPageAction();


### PR DESCRIPTION
## Description and issue
At this moment when the extension is loaded (update from AMO, reload from `about:debugging`), it does not check the existing tabs.
### List of significant changes made
-  check the existing tabs on first background script load

