### PR TITLE
Reduce unnecessary messaging

### DIFF
--- a/background.js
+++ b/background.js
@@ -29,9 +29,9 @@ function updatePageAction(tab, links) {
 
 function messageHandler(msg, sender) {
 	switch (msg.type) {
-		case 'feeds':
-			updatePageAction(sender.tab, msg.links);
-			break;
+	case 'feeds':
+		updatePageAction(sender.tab, msg.links);
+		break;
 	}
 }
 

--- a/background.js
+++ b/background.js
@@ -2,58 +2,49 @@ const TABS = {};
 
 function clickHandler(tab) {
 	browser.tabs.create({
-		url: TABS[tab.id].links[0].href
+		url: TABS[tab.id][0].href
 	});
-}
-
-function scanTabs(tabs) {
-	return tabs.forEach(scanPage);
 }
 
 function removeHandler(tabId) {
 	delete TABS[tabId];
 }
 
-function messageHandler(msg) {
-	if (msg === 'ready') {
-		browser.tabs.query({
-			active: true,
-			currentWindow: true
-		}).then(scanTabs).catch(console.error);
-	} else if (typeof msg === 'object') {
-		if (msg.links.length === 1) {
-			TABS[msg.id] = msg;
-			browser.pageAction.show(msg.id);
-			browser.pageAction.onClicked.addListener(clickHandler);
-		} else if (msg.links.length > 1) {
-			const url = new URL('popup.html', location.href);
-			url.searchParams.set('links', JSON.stringify(msg.links));
-			browser.pageAction.setPopup({
-				tabId: msg.id,
-				popup: url.toString()
-			});
-			browser.pageAction.show(msg.id);
-		}
+function updatePageAction(tab, links) {
+	if (links.length > 0) {
+		TABS[tab.id] = links;
+		browser.pageAction.show(tab.id);
 	}
-}
-
-function scanPage(tab) {
-	if (typeof tab === 'number') {
-		browser.tabs.get(tab).then(scanPage);
-	} else if (tab.status === 'complete') {
-		browser.tabs.sendMessage(tab.id, {
-			id: tab.id,
-			title: tab.title,
-			url: tab.url
+	if (links.length === 1) {
+		browser.pageAction.onClicked.addListener(clickHandler);
+	} else if (links.length > 1) {
+		const url = new URL(browser.runtime.getURL('popup.html'));
+		url.searchParams.set('links', JSON.stringify(links));
+		browser.pageAction.setPopup({
+			tabId: tab.id,
+			popup: url.toString()
 		});
 	}
 }
 
+function messageHandler(msg, sender) {
+	switch (msg.type) {
+		case 'feeds':
+			updatePageAction(sender.tab, msg.links);
+			break;
+	}
+}
+
+function scanPage(tab) {
+	if (tab.status === 'complete') {
+		browser.tabs.sendMessage(tab.id, {type: 'scan'});
+	}
+}
+
 function refreshAllTabsPageAction() {
-	browser.tabs.query({}).then(scanTabs).catch(console.error);
+	browser.tabs.query({}).then(tabs => tabs.forEach(scanPage)).catch(console.error);
 }
 
 browser.runtime.onMessage.addListener(messageHandler);
-browser.tabs.onUpdated.addListener(scanPage);
 browser.tabs.onRemoved.addListener(removeHandler);
 refreshAllTabsPageAction();

--- a/document.js
+++ b/document.js
@@ -26,9 +26,9 @@ function scanThisPage() {
 
 function messageHandler(msg) {
 	switch (msg.type) {
-		case 'scan':
-			scanThisPage();
-			break;
+	case 'scan':
+		scanThisPage();
+		break;
 	}
 }
 

--- a/document.js
+++ b/document.js
@@ -11,22 +11,26 @@ function mapLink(link) {
 	};
 }
 
-function messageHandler(tab) {
+function scanThisPage() {
 	const QUERY = 'link[rel="alternate"][type]';
 	const LINKS = Array.from(document.querySelectorAll(QUERY));
 
-	tab.links = LINKS.filter(filterLink).map(mapLink);
-	browser.runtime.sendMessage(tab);
+	const feedLinks = LINKS.filter(filterLink).map(mapLink);
+	if (feedLinks.length > 0) {
+		browser.runtime.sendMessage({
+			type: 'feeds',
+			links: feedLinks,
+		});
+	}
 }
 
-function pingExt() {
-	browser.runtime.sendMessage('ready');
+function messageHandler(msg) {
+	switch (msg.type) {
+		case 'scan':
+			scanThisPage();
+			break;
+	}
 }
 
 browser.runtime.onMessage.addListener(messageHandler);
-
-if (document.readyState === 'complete') {
-	pingExt();
-} else {
-	document.addEventListener('DOMContentLoaded', pingExt, {once: true});
-}
+scanThisPage();


### PR DESCRIPTION
## Description and issue
The message loop from the content script to background and back again is not necessary. The content script can actually send the list of feeds if there are any on its own.
### List of significant changes made
-  send messages to tabs only when a reload happens
-  send messages from tabs only when there are some feeds to list
- add `msg.type` to all messages for their easier handling
- use `browser.runtime.getURL` to get the popup URL
