### PR TITLE
Make localizable and add Czech (cs) translation

### DIFF
--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -1,0 +1,17 @@
+{
+  "extensionName": {
+    "message": "Awesome RSS",
+    "description": "Name of the extension."
+  },
+
+  "extensionDescription": {
+    "message": "Přidává ikonu pro přihlášení RSS/Atom kanálů do adresního řádku",
+    "description": "Description of the extension displayed in the add-ons manager."
+  },
+
+  "pageActionTooltip": {
+    "message": "Odebírat tuto stránku",
+    "description": "Tooltip displayed on moused hover over the page action. Should be the same as is Firefox https://transvision.mozfr.org/string/?entity=browser/chrome/browser/customizableui/customizableWidgets.properties:feed-button.tooltiptext2&repo=central"
+  }
+}
+

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,17 @@
+{
+  "extensionName": {
+    "message": "Awesome RSS",
+    "description": "Name of the extension."
+  },
+
+  "extensionDescription": {
+    "message": "Puts an RSS/Atom subscribe button back in URL bar",
+    "description": "Description of the extension displayed in the add-ons manager."
+  },
+
+  "pageActionTooltip": {
+    "message": "Subscribe to this page",
+    "description": "Tooltip displayed on moused hover over the page action. Should be the same as is Firefox https://transvision.mozfr.org/string/?entity=browser/chrome/browser/customizableui/customizableWidgets.properties:feed-button.tooltiptext2&repo=central"
+  }
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,23 +1,24 @@
 {
   "manifest_version": 2,
-  "name": "Awesome RSS",
+  "name": "__MSG_extensionName__",
   "developer": {
     "name": "Chris Zuber",
     "url": "https://chriszuber.com"
   },
   "version": "0.2.0",
-  "description": "Puts an RSS/Atom subscribe button back in URL bar",
+  "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/shgysk8zer0/awesome-rss",
   "icons": {
     "48": "icons/subscribe-16.svg"
   },
+  "default_locale": "en",
   "permissions": [
     "activeTab",
     "tabs"
   ],
   "page_action": {
     "default_icon": "icons/subscribe-16.svg",
-    "default_title": "Subscribe",
+    "default_title": "__MSG_pageActionTooltip__",
     "browser_style": true
   },
   "background": {


### PR DESCRIPTION
## Description and issue
Make the extension localizable.
### List of significant changes made
-  made the extension localizable
-  updated the page action tooltip to match the Firefox string
- added Czech translation

