### PR TITLE
Listen to `HistoryStateUpdated`

### DIFF
--- a/background.js
+++ b/background.js
@@ -36,8 +36,9 @@ function messageHandler(msg, sender) {
 }
 
 function scanPage(tab) {
-	if (tab.status === 'complete') {
-		browser.tabs.sendMessage(tab.id, {type: 'scan'});
+	// transitionType will be set on `HistoryStateUpdated` & status will not
+	if (tab.hasOwnProperty('transitionType') || tab.status === 'complete') {
+		browser.tabs.sendMessage(tab.id || tab.tabId, {type: 'scan'});
 	}
 }
 
@@ -47,4 +48,5 @@ function refreshAllTabsPageAction() {
 
 browser.runtime.onMessage.addListener(messageHandler);
 browser.tabs.onRemoved.addListener(removeHandler);
+browser.webNavigation.onHistoryStateUpdated.addListener(scanPage);
 refreshAllTabsPageAction();

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "name": "Chris Zuber",
     "url": "https://chriszuber.com"
   },
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/shgysk8zer0/awesome-rss",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -13,8 +13,8 @@
   },
   "default_locale": "en",
   "permissions": [
-    "activeTab",
-    "tabs"
+    "tabs",
+    "webNavigation"
   ],
   "page_action": {
     "default_icon": "icons/subscribe-16.svg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-rss",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Puts an RSS/Atom subscribe button back in URL bar",
   "keywords": [
     "WebExtension",


### PR DESCRIPTION
## Use `webNavigation` to detect changes in history / page updates. Fixes #25 

### List of significant changes made
- Add webNavigation permission (required to add listener)
- Remove activeTab permission
- Re-scan pages on navigation events

