### PR TITLE
Listen for tab updates

### DIFF
--- a/background.js
+++ b/background.js
@@ -45,6 +45,8 @@ function scanPage(tab) {
 	// transitionType will be set on `HistoryStateUpdated` & status will not
 	if (tab.hasOwnProperty('transitionType') || tab.status === 'complete') {
 		browser.tabs.sendMessage(tab.id || tab.tabId, {type: 'scan'});
+	} else if (typeof(tab) === 'number') {
+		browser.tabs.sendMessage(tab, {type: 'scan'});
 	}
 }
 
@@ -54,5 +56,5 @@ function refreshAllTabsPageAction() {
 
 browser.runtime.onMessage.addListener(messageHandler);
 browser.tabs.onRemoved.addListener(removeHandler);
-browser.webNavigation.onHistoryStateUpdated.addListener(scanPage);
+browser.tabs.onUpdated.addListener(scanPage);
 refreshAllTabsPageAction();

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,6 @@
   "default_locale": "en",
   "permissions": [
     "tabs",
-    "webNavigation",
     "storage"
   ],
   "page_action": {


### PR DESCRIPTION
Watch tabs for updates. Fixes #31

Changes
- Remove webNavigation permission in favor of tab update
- Add (number) tabId support to `scanPage`

