### PR TITLE
Add option to control opening of feeds

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,14 +10,13 @@ function removeHandler(tabId) {
 	delete TABS[tabId];
 }
 
-function updatePageAction(tab, links) {
+async function updatePageAction(tab, links) {
 	if (links.length > 0) {
 		TABS[tab.id] = links;
-		browser.storage.local.get('icon').then(icon => {
-			browser.pageAction.setIcon({
-				tabId: tab.id,
-				path: icon.icon || 'icons/subscribe-16.svg'
-			});
+		const opts = await browser.storage.local.get('icon');
+		browser.pageAction.setIcon({
+			tabId: tab.id,
+			path: opts.icon || 'icons/subscribe-16.svg'
 		});
 		browser.pageAction.show(tab.id);
 	}
@@ -50,8 +49,10 @@ function scanPage(tab) {
 	}
 }
 
-function refreshAllTabsPageAction() {
-	browser.tabs.query({}).then(tabs => tabs.forEach(scanPage)).catch(console.error);
+async function refreshAllTabsPageAction() {
+	const tabs = await browser.tabs.query();
+	tabs.forEach(scanPage);
+	// browser.tabs.query({}).then(tabs => tabs.forEach(scanPage)).catch(console.error);
 }
 
 browser.runtime.onMessage.addListener(messageHandler);

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "name": "Chris Zuber",
     "url": "https://chriszuber.com"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/shgysk8zer0/awesome-rss",
   "icons": {

--- a/options.html
+++ b/options.html
@@ -17,11 +17,15 @@
 					<option value="icons/subscribe-orange-16.svg">Orange icon</option>
 				</select>
 			</fieldset>
-			<!--<fieldset>
+			<fieldset>
 				<legend>Popup Options</legend>
-				<label for="bold">Use bold text</label>
-				<input type="checkbox" name="bold" id="bold" />
-			</fieldset>-->
+				<label for="openFeed">Use bold text</label>
+				<select name="openFeed" id="openFeed" required="">
+					<option value="current">Current tab</option>
+					<option value="tab">New tab</option>
+					<option value="window">New window</option>
+				</select>
+			</fieldset>
 			<button type="submit">Save</button>
 			<button type="reset">Reset all to defaults</button>
 			<hr />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-rss",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Puts an RSS/Atom subscribe button back in URL bar",
   "keywords": [
     "WebExtension",

--- a/popup.js
+++ b/popup.js
@@ -29,9 +29,7 @@ async function openFeed(click) {
 			browser.windows.create({url: this.href});
 			break;
 		case 'tab':
-			browser.tabs.create({
-				url: this.href,
-			});
+			browser.tabs.create({url: this.href});
 			break;
 		case 'current':
 			browser.tabs.update(null, {url: this.href});

--- a/popup.js
+++ b/popup.js
@@ -20,11 +20,29 @@ function init() {
 	}
 }
 
-function openFeed(click) {
+async function openFeed(click) {
 	click.preventDefault();
-	browser.tabs.create({
-		url: this.href,
-	});
+	const opts = await browser.storage.local.get();
+	if (opts.hasOwnProperty('openFeed')) {
+		switch (opts.openFeed) {
+		case 'window':
+			browser.windows.create({url: this.href});
+			break;
+		case 'tab':
+			browser.tabs.create({
+				url: this.href,
+			});
+			break;
+		case 'current':
+			browser.tabs.update(null, {url: this.href});
+			break;
+		default:
+			throw new Error(`Unsupported open feed method: ${opts.openFeed}`);
+		}
+	} else {
+		browser.tabs.update(null, {url: this.href});
+	}
+
 }
 
 if (['interactive', 'complete'].includes(document.readyState)) {

--- a/popup.js
+++ b/popup.js
@@ -22,7 +22,7 @@ function init() {
 
 async function openFeed(click) {
 	click.preventDefault();
-	const opts = await browser.storage.local.get();
+	const opts = await browser.storage.local.get('openFeed');
 	if (opts.hasOwnProperty('openFeed')) {
 		switch (opts.openFeed) {
 		case 'window':


### PR DESCRIPTION
## Add option in settings to control opening feeds in:
- Current tab
- New tab
- New window

Resolves #30 

### List of significant changes made
-  Add `openFeed` to `options.html`
- Control opening feeds based on this preference
- Make all Promise handling use `async`/`await`
