### PR TITLE
Set icons using object keys instead of icon path

### DIFF
--- a/background.js
+++ b/background.js
@@ -108,6 +108,7 @@ async function updateHandler(update) {
 		storage.set(defaultOpts);
 	} else if (update.reason === 'update') {
 		const opts = await storage.get();
+		console.info(opts);
 		switch (update.previousVersion) {
 		case '1.0.0':
 		case '1.0.1':
@@ -122,6 +123,7 @@ async function updateHandler(update) {
 			if (! opts.hasOwnProperty('openFeed')) {
 				opts.openFeed = defaultOpts.openFeed;
 			}
+			console.info(opts);
 			storage.set(opts);
 			break;
 		}

--- a/background.js
+++ b/background.js
@@ -116,7 +116,8 @@ async function updateHandler(update) {
 				const key = Object.keys(ICONS).find(icon => {
 					return ICONS[icon] === opts.icon.replace('16', '64');
 				});
-				opts.icon =ICONS.hasOwnProperty(key) ? key : defaultOpts.icon;
+				console.log(key);
+				opts.icon = ICONS.hasOwnProperty(key) ? key : defaultOpts.icon;
 			} else {
 				opts.icon = defaultOpts.icon;
 			}

--- a/background.js
+++ b/background.js
@@ -116,7 +116,7 @@ async function updateHandler(update) {
 				const key = Object.keys(ICONS).find(icon => {
 					return ICONS[icon] === opts.icon.replace('16', '64');
 				});
-				opts.icon = key || defaultOpts.icon;
+				opts.icon = key instanceof String ? key : defaultOpts.icon;
 			} else {
 				opts.icon = defaultOpts.icon;
 			}
@@ -125,7 +125,6 @@ async function updateHandler(update) {
 			}
 			console.info(opts);
 			storage.set(opts);
-			break;
 		}
 	}
 }

--- a/background.js
+++ b/background.js
@@ -116,7 +116,7 @@ async function updateHandler(update) {
 				const key = Object.keys(ICONS).find(icon => {
 					return ICONS[icon] === opts.icon.replace('16', '64');
 				});
-				opts.icon = key instanceof String ? key : defaultOpts.icon;
+				opts.icon =ICONS.hasOwnProperty(key) ? key : defaultOpts.icon;
 			} else {
 				opts.icon = defaultOpts.icon;
 			}

--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 const TABS = {};
 const defaultOpts = {
-	icons: 'light',
+	icon: 'light',
 	openFeed: 'currennt',
 };
 

--- a/background.js
+++ b/background.js
@@ -102,13 +102,12 @@ async function optChange(opts) {
 
 async function updateHandler(update) {
 	if (update.temporary) {
-		console.log(update);
+		storage.get().then(opts => console.log(update, opts));
 	}
 	if (update.reason === 'install') {
 		storage.set(defaultOpts);
 	} else if (update.reason === 'update') {
 		const opts = await storage.get();
-		console.info(opts);
 		switch (update.previousVersion) {
 		case '1.0.0':
 		case '1.0.1':
@@ -116,7 +115,6 @@ async function updateHandler(update) {
 				const key = Object.keys(ICONS).find(icon => {
 					return ICONS[icon] === opts.icon.replace('16', '64');
 				});
-				console.log(key);
 				opts.icon = ICONS.hasOwnProperty(key) ? key : defaultOpts.icon;
 			} else {
 				opts.icon = defaultOpts.icon;
@@ -124,7 +122,6 @@ async function updateHandler(update) {
 			if (! opts.hasOwnProperty('openFeed')) {
 				opts.openFeed = defaultOpts.openFeed;
 			}
-			console.info(opts);
 			storage.set(opts);
 		}
 	}

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "name": "Chris Zuber",
     "url": "https://chriszuber.com"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/shgysk8zer0/awesome-rss",
   "icons": {

--- a/options.html
+++ b/options.html
@@ -12,9 +12,9 @@
 				<legend>Theme Options</legend>
 				<label for="icon"></label>
 				<select name="icon" id="icon" required="">
-					<option value="icons/subscribe-64.svg">Light theme icon</option>
-					<option value="icons/subscribe-dark-64.svg">Dark theme icon</option>
-					<option value="icons/subscribe-orange-64.svg">Orange icon</option>
+					<option value="light">Light theme icon</option>
+					<option value="dark">Dark theme icon</option>
+					<option value="orange">Orange icon</option>
 				</select>
 			</fieldset>
 			<fieldset>

--- a/options.html
+++ b/options.html
@@ -27,8 +27,6 @@
 				</select>
 			</fieldset>
 			<button type="reset">Reset all to defaults</button>
-			<hr />
-			<em><b>Note: </b> Any open tabs will need to be refreshed for changes to take effect</em>
 		</form>
 	</body>
 </html>

--- a/options.html
+++ b/options.html
@@ -19,7 +19,7 @@
 			</fieldset>
 			<fieldset>
 				<legend>Popup Options</legend>
-				<label for="openFeed">Use bold text</label>
+				<label for="openFeed">Open feed using</label>
 				<select name="openFeed" id="openFeed" required="">
 					<option value="current">Current tab</option>
 					<option value="tab">New tab</option>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-rss",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Puts an RSS/Atom subscribe button back in URL bar",
   "keywords": [
     "WebExtension",


### PR DESCRIPTION
## Use `{$icon: $path}` to set icons. Resolves #43 

### List of significant changes made
-  Use objects to store icon paths and set icon by key
-  Provide fallback to default icon

