### PR TITLE
Add disabled state for Firefox 58

### DIFF
--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -12,6 +12,10 @@
   "pageActionTooltip": {
     "message": "Odebírat tuto stránku",
     "description": "Tooltip displayed on moused hover over the page action. Should be the same as is Firefox https://transvision.mozfr.org/string/?entity=browser/chrome/browser/customizableui/customizableWidgets.properties:feed-button.tooltiptext2&repo=central"
+  },
+  "extensionNA": {
+    "message": "Není k dispozici",
+    "description": "Message to show when page is secure or there are no feeds"
   }
 }
 

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -12,6 +12,10 @@
   "pageActionTooltip": {
     "message": "Abonnieren Sie diese Seite",
     "description": "Tooltip displayed on moused hover over the page action. Should be the same as is Firefox https://transvision.mozfr.org/string/?entity=browser/chrome/browser/customizableui/customizableWidgets.properties:feed-button.tooltiptext2&repo=central"
+  },
+  "extensionNA": {
+    "message": "Nicht verfügbar",
+    "description": "Message to show when page is secure or there are no feeds"
   }
 }
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -12,6 +12,10 @@
   "pageActionTooltip": {
     "message": "Subscribe to this page",
     "description": "Tooltip displayed on moused hover over the page action. Should be the same as is Firefox https://transvision.mozfr.org/string/?entity=browser/chrome/browser/customizableui/customizableWidgets.properties:feed-button.tooltiptext2&repo=central"
+  },
+  "extensionNA": {
+    "message": "Unavailable",
+    "description": "Message to show when page is secure or there are no feeds"
   }
 }
 

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -12,6 +12,10 @@
   "pageActionTooltip": {
     "message": "Suscribirse a esta página",
     "description": "Tooltip displayed on moused hover over the page action. Should be the same as is Firefox https://transvision.mozfr.org/string/?entity=browser/chrome/browser/customizableui/customizableWidgets.properties:feed-button.tooltiptext2&repo=central"
+  },
+  "extensionNA": {
+    "message": "Indisponible",
+    "description": "Message to show when page is secure or there are no feeds"
   }
 }
 

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -12,6 +12,10 @@
   "pageActionTooltip": {
     "message": "Abonnez-vous à cette page",
     "description": "Tooltip displayed on moused hover over the page action. Should be the same as is Firefox https://transvision.mozfr.org/string/?entity=browser/chrome/browser/customizableui/customizableWidgets.properties:feed-button.tooltiptext2&repo=central"
+  },
+  "extensionNA": {
+    "message": "Indisponible",
+    "description": "Message to show when page is secure or there are no feeds"
   }
 }
 

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -12,6 +12,10 @@
   "pageActionTooltip": {
     "message": "Iscriviti a questa pagina",
     "description": "Tooltip displayed on moused hover over the page action. Should be the same as is Firefox https://transvision.mozfr.org/string/?entity=browser/chrome/browser/customizableui/customizableWidgets.properties:feed-button.tooltiptext2&repo=central"
+  },
+  "extensionNA": {
+    "message": "non disponibile",
+    "description": "Message to show when page is secure or there are no feeds"
   }
 }
 

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -12,6 +12,10 @@
   "pageActionTooltip": {
     "message": "Подписаться на эту страницу",
     "description": "Tooltip displayed on moused hover over the page action. Should be the same as is Firefox https://transvision.mozfr.org/string/?entity=browser/chrome/browser/customizableui/customizableWidgets.properties:feed-button.tooltiptext2&repo=central"
+  },
+  "extensionNA": {
+    "message": "Недоступен",
+    "description": "Message to show when page is secure or there are no feeds"
   }
 }
 

--- a/icons/subscribe-disabled.svg
+++ b/icons/subscribe-disabled.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 16 16">
+  <path fill="#7F7F80" fill-opacity="0.3" d="M3.5 10A2.5 2.5 0 1 0 6 12.5 2.5 2.5 0 0 0 3.5 10zM2 1a1 1 0 0 0 0 2 10.883 10.883 0 0 1 11 11 1 1 0 0 0 2 0A12.862 12.862 0 0 0 2 1zm0 4a1 1 0 0 0 0 2 6.926 6.926 0 0 1 7 7 1 1 0 0 0 2 0 8.9 8.9 0 0 0-9-9z"></path>
+</svg>

--- a/js/background.js
+++ b/js/background.js
@@ -92,26 +92,18 @@ function messageHandler(msg, sender) {
 }
 
 function scanPage(tab) {
+	const tabId = typeof(tab) === 'number' ? tab : tab.id || tab.tabId;
 	browser.pageAction.setIcon({
-		tabId: tab.id || tab.tabId,
+		tabId: tabId,
 		path: ICONS.disabled,
 	});
 
 	browser.pageAction.setTitle({
-		tabId: tab.id || tab.tabId,
+		tabId: tabId,
 		title: browser.i18n.getMessage('extensionNA'),
 	});
 
-	// transitionType will be set on `HistoryStateUpdated` & status will not
-	if (tab.hasOwnProperty('transitionType') || tab.status === 'complete') {
-		browser.tabs.sendMessage(tab.id || tab.tabId, {type: 'scan'});
-		browser.pageAction.setTitle({
-			title: browser.i18n.getMessage('extensionNA'),
-			tabId: tab.id || tab.tabId,
-		});
-	} else if (typeof(tab) === 'number') {
-		browser.tabs.sendMessage(tab, {type: 'scan'});
-	}
+	browser.tabs.sendMessage(tabId, {type: 'scan'});
 }
 
 async function refreshAllTabsPageAction() {

--- a/js/background.js
+++ b/js/background.js
@@ -44,6 +44,7 @@ function removeHandler(tabId) {
 	delete TABS[tabId];
 }
 
+// https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/pageAction/setTitle
 async function updatePageAction(tab, links) {
 	if (links.length > 0) {
 		TABS[tab.id] = links;
@@ -55,6 +56,10 @@ async function updatePageAction(tab, links) {
 			tabId: tab.id,
 			path: ICONS[opts.icon]
 		});
+		browser.pageAction.setTitle({
+			tabId: tab.id,
+			title: browser.i18n.getMessage('pageActionTooltip'),
+		});
 		browser.pageAction.show(tab.id);
 	}
 	if (links.length === 1) {
@@ -65,6 +70,11 @@ async function updatePageAction(tab, links) {
 		browser.pageAction.setPopup({
 			tabId: tab.id,
 			popup: url.toString()
+		});
+	} else {
+		browser.pageAction.setTitle({
+			tabId: tab.id,
+			title: browser.i18n.getMessage('extensionNA'),
 		});
 	}
 }
@@ -81,6 +91,11 @@ function scanPage(tab) {
 	// transitionType will be set on `HistoryStateUpdated` & status will not
 	if (tab.hasOwnProperty('transitionType') || tab.status === 'complete') {
 		browser.tabs.sendMessage(tab.id || tab.tabId, {type: 'scan'});
+		browser.pageAction.setTitle({
+			title: browser.i18n.getMessage('extensionNA'),
+			tabId: tab.id || tab.tabId,
+		});
+		window.dne = console.log;
 	} else if (typeof(tab) === 'number') {
 		browser.tabs.sendMessage(tab, {type: 'scan'});
 	}

--- a/js/background.js
+++ b/js/background.js
@@ -14,9 +14,10 @@ const defaultOpts = {
 const storage = browser.storage.sync;
 
 const ICONS = {
-	light: 'icons/subscribe-64.svg',
-	dark: 'icons/subscribe-dark-64.svg',
-	orange: 'icons/subscribe-orange-64.svg',
+	light:    'icons/subscribe-64.svg',
+	dark:     'icons/subscribe-dark-64.svg',
+	orange:   'icons/subscribe-orange-64.svg',
+	disabled: 'icons/subscribe-disabled.svg',
 };
 
 async function clickHandler(tab) {
@@ -26,12 +27,15 @@ async function clickHandler(tab) {
 		case 'window':
 			browser.windows.create({url: TABS[tab.id][0].href});
 			break;
+
 		case 'tab':
 			browser.tabs.create({url: TABS[tab.id][0].href});
 			break;
+
 		case 'current':
 			browser.tabs.update(null, {url: TABS[tab.id][0].href});
 			break;
+
 		default:
 			throw new Error(`Unsupported open feed method: ${opts.openFeed}`);
 		}
@@ -44,37 +48,37 @@ function removeHandler(tabId) {
 	delete TABS[tabId];
 }
 
-// https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/pageAction/setTitle
 async function updatePageAction(tab, links) {
 	if (links.length > 0) {
-		TABS[tab.id] = links;
 		const opts = await storage.get('icon');
+		TABS[tab.id] = links;
+
 		if (! ICONS.hasOwnProperty(opts.icon)) {
 			opts.icon = defaultOpts.icon;
 		}
+
 		browser.pageAction.setIcon({
 			tabId: tab.id,
 			path: ICONS[opts.icon]
 		});
+
 		browser.pageAction.setTitle({
 			tabId: tab.id,
 			title: browser.i18n.getMessage('pageActionTooltip'),
 		});
+
 		browser.pageAction.show(tab.id);
 	}
+
 	if (links.length === 1) {
 		browser.pageAction.onClicked.addListener(clickHandler);
 	} else if (links.length > 1) {
 		const url = new URL(browser.runtime.getURL('popup.html'));
+
 		url.searchParams.set('links', JSON.stringify(links));
 		browser.pageAction.setPopup({
 			tabId: tab.id,
 			popup: url.toString()
-		});
-	} else {
-		browser.pageAction.setTitle({
-			tabId: tab.id,
-			title: browser.i18n.getMessage('extensionNA'),
 		});
 	}
 }
@@ -88,6 +92,16 @@ function messageHandler(msg, sender) {
 }
 
 function scanPage(tab) {
+	browser.pageAction.setIcon({
+		tabId: tab.id || tab.tabId,
+		path: ICONS.disabled,
+	});
+
+	browser.pageAction.setTitle({
+		tabId: tab.id || tab.tabId,
+		title: browser.i18n.getMessage('extensionNA'),
+	});
+
 	// transitionType will be set on `HistoryStateUpdated` & status will not
 	if (tab.hasOwnProperty('transitionType') || tab.status === 'complete') {
 		browser.tabs.sendMessage(tab.id || tab.tabId, {type: 'scan'});
@@ -95,7 +109,6 @@ function scanPage(tab) {
 			title: browser.i18n.getMessage('extensionNA'),
 			tabId: tab.id || tab.tabId,
 		});
-		window.dne = console.log;
 	} else if (typeof(tab) === 'number') {
 		browser.tabs.sendMessage(tab, {type: 'scan'});
 	}
@@ -110,15 +123,29 @@ async function optChange(opts) {
 	if (opts.hasOwnProperty('icon') && opts.icon.newValue !== opts.icon.oldValue) {
 		const tabs = await browser.tabs.query({status: 'complete'});
 		let icon = opts.icon.newValue;
+
 		if (! ICONS.hasOwnProperty(icon)) {
 			icon = ICONS[defaultOpts.icon];
 		} else {
 			icon = ICONS[icon];
 		}
-		tabs.forEach(tab => browser.pageAction.setIcon({
-			tabId: tab.id,
-			path: icon
-		}));
+
+		tabs.forEach(async tab => {
+			/**
+			 * Since we do not want to rescan the page to know if there are feeds
+			 * and there is no `getIcon` method, check the title to know if we
+			 * can update the icon without implying that there is a feed to
+			 * subscribe to.
+			*/
+			const title = await browser.pageAction.getTitle({tabId: tab.id});
+
+			if (title !== browser.i18n.getMessage('extensionNA')) {
+				browser.pageAction.setIcon({
+					tabId: tab.id,
+					path: icon,
+				});
+			}
+		});
 	}
 }
 
@@ -126,6 +153,7 @@ async function updateHandler(update) {
 	if (update.temporary) {
 		storage.get().then(opts => console.log({update, opts}));
 	}
+
 	if (update.reason === 'install') {
 		storage.set(defaultOpts);
 	} else if (update.reason === 'update') {

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,6 @@
   ],
   "page_action": {
     "default_icon": "icons/subscribe-64.svg",
-    "default_title": "__MSG_pageActionTooltip__",
     "browser_style": true
   },
   "options_ui": {

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "name": "Chris Zuber",
     "url": "https://chriszuber.com"
   },
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/shgysk8zer0/awesome-rss",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "stylelint-config-standard": "^17.0.0",
     "rollup": "^0.50.0",
     "svg-sprite-generator": "0.0.7",
-    "web-ext": "^2.0.0"
+    "web-ext": "^2.2.2"
   },
   "scripts": {
     "git:fetch": "git fetch --prune --tags",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-rss",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Puts an RSS/Atom subscribe button back in URL bar",
   "keywords": [
     "WebExtension",

--- a/popup.html
+++ b/popup.html
@@ -15,7 +15,7 @@
 			</a>
 		</template>
 		<template id="bold-template">
-			<a href="" title="" class="panel-list-item
+			<a href="" title="" class="panel-list-item">
 				<b data-prop="title"></b>
 			</a>
 		</template>


### PR DESCRIPTION
## Update title & icon when shown with no feeds. Fixes #56 

### List of significant changes made
- Add new message for title when disabled
- Add new disabled icon with 0.3 opacity
- Set as title & icon when scanning page
- Update title & icon if feed found
- Fix bold template
- Update to `web-ext@2.2.2`

