### PR TITLE
Add Feedly support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "img/adwaita-icons"]
 	path = img/adwaita-icons
 	url = git://github.com/shgysk8zer0/adwaita-icons.git
+[submodule "img/logos"]
+	path = img/logos
+	url = https://github.com/shgysk8zer0/logos.git

--- a/icons/subscribe-green-64.svg
+++ b/icons/subscribe-green-64.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 16 16">
+  <path fill="#22E522" d="M3.5 10A2.5 2.5 0 1 0 6 12.5 2.5 2.5 0 0 0 3.5 10zM2 1a1 1 0 0 0 0 2 10.883 10.883 0 0 1 11 11 1 1 0 0 0 2 0A12.862 12.862 0 0 0 2 1zm0 4a1 1 0 0 0 0 2 6.926 6.926 0 0 1 7 7 1 1 0 0 0 2 0 8.9 8.9 0 0 0-9-9z"></path>
+</svg>
+

--- a/img/icons.csv
+++ b/img/icons.csv
@@ -13,3 +13,5 @@ template,img/adwaita-icons/places/folder-templates.svg
 star,img/adwaita-icons/places/user-bookmarks.svg
 margins,img/margins.svg
 padding,img/padding.svg
+rss,img/adwaita-icons/mimetypes/application-rss+xml.svg
+feedly,img/logos/feedly.svg

--- a/js/options.js
+++ b/js/options.js
@@ -8,21 +8,29 @@ window.addEventListener('DOMContentLoaded', async () => {
 	const form = document.forms.options;
 	const inputs = $('[name]', form);
 
-	Object.keys(opts).forEach(key => {
-		const input = inputs.find(el => el.name === key);
-		if (input instanceof HTMLInputElement) {
-			switch(input.type) {
-			case 'checkbox':
-				input.checked = true;
-				break;
-			default:
+	Object.entries(opts).forEach(([key, value]) => {
+		const matches = inputs.filter(el => el.name === key);
+		matches.forEach(input => {
+			if (input instanceof HTMLInputElement) {
+				switch(input.type) {
+				case 'checkbox':
+					input.checked = true;
+					break;
+				case 'radio':
+					if (input.value === value) {
+						input.checked = true;
+					}
+					break;
+				default:
+					input.value = opts[key];
+				}
+			} else if (input instanceof HTMLSelectElement) {
 				input.value = opts[key];
+			} else {
+				storage.remove(key);
 			}
-		} else if (input instanceof HTMLSelectElement) {
-			input.value = opts[key];
-		} else {
-			storage.remove(key);
-		}
+		});
+
 
 		$('output[for]', form).forEach(output => {
 			const input = document.getElementById(output.getAttribute('for'));
@@ -36,7 +44,8 @@ window.addEventListener('DOMContentLoaded', async () => {
 			if (change.target instanceof HTMLInputElement) {
 				switch (change.target.type) {
 				case 'checkbox':
-					opts[change.target.name] = change.target.checked;
+				case 'radio':
+					opts[change.target.name] = change.target.value;
 					break;
 				default:
 					opts[change.target.name] = change.target.value;

--- a/js/popup.js
+++ b/js/popup.js
@@ -65,24 +65,16 @@ async function init() {
 
 async function openFeed(click) {
 	click.preventDefault();
-	const opts = await storage.get('openFeed');
-	if (opts.hasOwnProperty('openFeed')) {
-		switch (opts.openFeed) {
-		case 'window':
-			browser.windows.create({url: this.href});
-			break;
-		case 'tab':
-			browser.tabs.create({url: this.href});
-			break;
-		case 'current':
-			browser.tabs.update(null, {url: this.href});
-			break;
-		default:
-			throw new Error(`Unsupported open feed method: ${opts.openFeed}`);
+
+	const opts = await storage.get(['openFeed', 'service']);
+	browser.runtime.sendMessage({
+		type: 'openFeed',
+		params: {
+			feed: this.href,
+			target: opts.openFeed,
+			service: opts.service,
 		}
-	} else {
-		browser.tabs.update(null, {url: this.href});
-	}
+	});
 }
 
 if (['interactive', 'complete'].includes(document.readyState)) {

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "name": "Chris Zuber",
     "url": "https://chriszuber.com"
   },
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/shgysk8zer0/awesome-rss",
   "icons": {

--- a/options.html
+++ b/options.html
@@ -20,7 +20,25 @@
 					<option value="light">Light theme icon</option>
 					<option value="dark">Dark theme icon</option>
 					<option value="orange">Orange icon</option>
+					<option value="green">Green icon</option>
 				</select>
+			</fieldset>
+			<fieldset>
+				<legend>Subscribe Using</legend>
+				<label for="subscribe-rss" class="browser-style-label" title="Select icon">
+					<svg class="icon" width="32" height="32">
+						<use xlink:href="icons.svg#rss" />
+					</svg>
+					<span>RSS</span>
+				</label>
+				<input type="radio" name="service" id="subscribe-rss" value="rss" checked="" />
+				<label for="subscribe-feedly" class="browser-style-label" title="Select icon">
+					<svg class="icon" width="32" height="32">
+						<use xlink:href="icons.svg#feedly" />
+					</svg>
+					<span>Feedly</span>
+				</label>
+				<input type="radio" name="service" value="feedly" id="subscribe-feedly" />
 			</fieldset>
 			<fieldset>
 				<legend>Popup Options</legend>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-rss",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Puts an RSS/Atom subscribe button back in URL bar",
   "keywords": [
     "WebExtension",


### PR DESCRIPTION
## Add support for feed services, beginning with Feedly. Resolves #58 

### List of significant changes made
- Add green RSS icon and set as icon option
- Add options to pick feed service
- Add dedicated function to open feeds
- Add message handler to use `openFeed` to open feeds
- Pass params via message to `background.js` to open feeds
- Add ability to convert URL to Feedly format
- Update storage on update to set default feed service (RSS)