### PR TITLE
Update resetting options form

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -109,8 +109,13 @@ function messageHandler(msg, sender) {
 	case 'feeds':
 		updatePageAction(sender.tab, msg.links);
 		break;
+
 	case 'openFeed':
 		openFeed(msg.params);
+		break;
+
+	case 'resetOpts':
+		storage.set(defaultOpts);
 		break;
 	}
 }

--- a/js/options.js
+++ b/js/options.js
@@ -24,47 +24,51 @@ window.addEventListener('DOMContentLoaded', async () => {
 		}
 	}
 
-	const storage = browser.storage.sync;
-	const opts = await storage.get();
-	const form = document.forms.options;
-	const inputs = $('[name]', form);
+	async function setValuesFromStorage({
+		storage = browser.storage.sync,
+		form = document.forms.options,
+		opts
+	}) {
+		const inputs = $('[name]', form);
 
-	$('[data-locale-text]', form).forEach(getText);
-	$('[data-locale-title]', form).forEach(getTitle);
-	$('[data-locale-placeholder]', form).forEach(getPlaceholder);
-
-	Object.entries(opts).forEach(([key, value]) => {
-		const matches = inputs.filter(el => el.name === key);
-		matches.forEach(input => {
-			if (input instanceof HTMLInputElement) {
-				switch(input.type) {
-				case 'checkbox':
-					input.checked = true;
-					break;
-				case 'radio':
-					if (input.value === value) {
+		Object.entries(opts).forEach(([key, value]) => {
+			const matches = inputs.filter(el => el.name === key);
+			matches.forEach(input => {
+				if (input instanceof HTMLInputElement) {
+					switch(input.type) {
+					case 'checkbox':
 						input.checked = true;
+						break;
+					case 'radio':
+						if (input.value === value) {
+							input.checked = true;
+						}
+						break;
+					default:
+						input.value = opts[key];
 					}
-					break;
-				default:
+				} else if (input instanceof HTMLSelectElement) {
 					input.value = opts[key];
+				} else {
+					storage.remove(key);
 				}
-			} else if (input instanceof HTMLSelectElement) {
-				input.value = opts[key];
-			} else {
-				storage.remove(key);
-			}
+			});
 		});
+	}
 
+	const storage = browser.storage.sync;
+	const form = document.forms.options;
+	const opts = await storage.get();
 
-		$('output[for]', form).forEach(output => {
-			const input = document.getElementById(output.getAttribute('for'));
-			input.addEventListener('input', change => output.textContent = change.target.value);
-			output.textContent = input.value;
-		});
+	setValuesFromStorage({form, storage, opts});
+
+	$('output[for]', form).forEach(output => {
+		const input = document.getElementById(output.getAttribute('for'));
+		input.addEventListener('input', change => output.textContent = change.target.value);
+		output.textContent = input.value;
 	});
 
-	inputs.forEach(input => {
+	$('[name]', form).forEach(input => {
 		input.addEventListener('change', change => {
 			if (change.target instanceof HTMLInputElement) {
 				switch (change.target.type) {
@@ -82,12 +86,23 @@ window.addEventListener('DOMContentLoaded', async () => {
 		});
 	});
 
+	$('[data-locale-text]', form).forEach(getText);
+	$('[data-locale-title]', form).forEach(getTitle);
+	$('[data-locale-placeholder]', form).forEach(getPlaceholder);
+
 	form.addEventListener('submit', submit => submit.preventDefault());
 	form.addEventListener('reset', reset => {
+		reset.preventDefault();
 		if (confirm('This will clear your settings')) {
-			storage.clear();
-		} else {
-			reset.preventDefault();
+			browser.runtime.sendMessage({type: 'resetOpts'});
+
+			setTimeout(async () => {
+				setValuesFromStorage({
+					form,
+					storage,
+					opts: await storage.get(),
+				});
+			}, 500);
 		}
 	});
 	form.hidden = false;

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "name": "Chris Zuber",
     "url": "https://shgysk8zer0.github.io"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/shgysk8zer0/awesome-rss",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-rss",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Puts an RSS/Atom subscribe button back in URL bar",
   "keywords": [
     "WebExtension",


### PR DESCRIPTION
## Reset instead of clear options on options form reset. Fixes #62

### List of significant changes made
- Add message handler to reset options to defaults
- Move setting form values to own function
- Set form values on page load
- Send message to reset options on form reset
- Update form values after reset
