### PR TITLE
[WIP] Replace ambient content-script with activeTab

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,11 +13,12 @@
   },
   "default_locale": "en",
   "permissions": [
-    "tabs",
+    "activeTab",
     "storage"
   ],
-  "page_action": {
+  "browser_action": {
     "default_icon": "icons/subscribe-64.svg",
+    "default_popup": "popup.html",
     "browser_style": true
   },
   "options_ui": {
@@ -27,10 +28,6 @@
   "background": {
     "scripts": ["js/background.js"]
   },
-  "content_scripts": [{
-    "matches": ["<all_urls>"],
-    "js": ["js/document.js"]
-  }],
   "applications": {
     "gecko": {
         "id": "{97d566da-42c5-4ef4-a03b-5a2e5f7cbcb2}",


### PR DESCRIPTION
## Description and issue

Fixes https://github.com/shgysk8zer0/awesome-rss/issues/139

FYI, I don't expect this PR will be acceptable for the project, since the UI becomes less convenient. But worth a shot. :)

### List of significant changes made
-  awesome-rss no longer has a content script on all pages nor permission `tabs`. Thus, attack surface has been reduced to just pages that the users initiates awesome-rss (by clicking on the awesome-rss browser icon)
-  awesome-rss's icon is visible on all pages, even if the page has no RSS feed
- Users only learn whether a page has RSS feeds when they click on the icon, rather than by virtue of the icon being visible

### TODO
- [ ] Fix integration with RSS readers, e.g. feedly. This might be a bug in master?
- [ ] Test options
- [ ] Fix indentation