### PR TITLE
Add support for Feedbin subscription

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -55,6 +55,10 @@
     "message": "Mit Feedly abonnieren",
     "description": "Title attribute for input to select Feedly as subscription option"
   },
+  "title@feedbinSubscribe": {
+    "message": "Mit Feedbin abonnieren",
+    "description": "Title attribute for input to select Feedbin as subscription option"
+  },
   "title@inoreaderSubscribe": {
     "message": "Mit Inoreader abonnieren",
     "description": "Title attribute for input to select Inoreader as subscription option"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -55,6 +55,10 @@
     "message": "Subscribe using Feedly",
     "description": "Title attribute for input to select Feedly as subscription option"
   },
+  "title@feedbinSubscribe": {
+    "message": "Subscribe using Feedbin",
+    "description": "Title attribute for input to select Feedbin as subscription option"
+  },
   "title@inoreaderSubscribe": {
     "message": "Subscribe using Inoreader",
     "description": "Title attribute for input to select Inoreader as subscription option"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -55,6 +55,10 @@
     "message": "Suscribirse usando Feedly",
     "description": "Title attribute for input to select Feedly as subscription option"
   },
+  "title@feedbinSubscribe": {
+    "message": "Suscribirse usando Feedbin",
+    "description": "Title attribute for input to select Feedbin as subscription option"
+  },
   "title@inoreaderSubscribe": {
     "message": "Suscribirse usando Inoreader",
     "description": "Title attribute for input to select Inoreader as subscription option"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -57,6 +57,10 @@
     "message": "S'abonner avec Feedly",
     "description": "Title attribute for input to select Feedly as subscription option"
   },
+  "title@feedbinSubscribe": {
+    "message": "S'abonner avec Feedbin",
+    "description": "Title attribute for input to select Feedbin as subscription option"
+  },
   "title@inoreaderSubscribe": {
     "message": "S'abonner avec Inoreader",
     "description": "Title attribute for input to select Inoreader as subscription option"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -55,6 +55,10 @@
       "message": "Feedlyを使用して購読",
       "description": "Title attribute for input to select Feedly as subscription option"
     },
+    "title@feedbinSubscribe": {
+      "message": "Feedbinを使用して購読",
+      "description": "Title attribute for input to select Feedbin as subscription option"
+    },
     "title@inoreaderSubscribe": {
       "message": "Inoreaderを使用して購読",
       "description": "Title attribute for input to select Inoreader as subscription option"

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -55,6 +55,10 @@
     "message": "Subskrybuj za pomocą Feedly",
     "description": "Title attribute for input to select Feedly as subscription option"
   },
+  "title@feedbinSubscribe": {
+    "message": "Subskrybuj za pomocą Feedbin",
+    "description": "Title attribute for input to select Feedbin as subscription option"
+  },
   "title@inoreaderSubscribe": {
     "message": "Subskrybuj za pomocą Inoreadera",
     "description": "Title attribute for input to select Inoreader as subscription option"

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -55,6 +55,10 @@
     "message": "Inscreva-se usando o Feedly",
     "description": "Title attribute for input to select Feedly as subscription option"
   },
+  "title@feedbinSubscribe": {
+    "message": "Inscreva-se usando o Feedbin",
+    "description": "Title attribute for input to select Feedbin as subscription option"
+  },
   "title@inoreaderSubscribe": {
     "message": "Inscreva-se usando o Inoreader",
     "description": "Title attribute for input to select Inoreader as subscription option"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -55,6 +55,10 @@
     "message": "Пописаться с помощью Feedly",
     "description": "Title attribute for input to select Feedly as subscription option"
   },
+  "title@feedbinSubscribe": {
+    "message": "Пописаться с помощью Feedbin",
+    "description": "Title attribute for input to select Feedbin as subscription option"
+  },
   "title@inoreaderSubscribe": {
     "message": "Пописаться с помощью Inoreader",
     "description": "Title attribute for input to select Inoreader as subscription option"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -55,6 +55,10 @@
     "message": "使用 Feedly 订阅",
     "description": "Title attribute for input to select Feedly as subscription option"
   },
+  "title@feedbinSubscribe": {
+    "message": "使用 Feedbin 订阅",
+    "description": "Title attribute for input to select Feedbin as subscription option"
+  },
   "title@inoreaderSubscribe": {
     "message": "使用 Inoreader 订阅",
     "description": "Title attribute for input to select Inoreader as subscription option"

--- a/img/icons.csv
+++ b/img/icons.csv
@@ -20,3 +20,4 @@ inoreader,img/logos/inoreader.svg
 tiny-tiny-rss,img/logos/tiny-tiny-rss.svg
 nextcloud,img/logos/nextcloud.svg
 fresh-rss,img/logos/fresh-rss.svg
+feedbin,img/logos/feedbin.svg

--- a/js/background.js
+++ b/js/background.js
@@ -36,6 +36,10 @@ async function openFeed({feed, target = 'current', service = 'rss', index = unde
 		feedly.pathname += encodeURIComponent(feed);
 		url = feedly;
 		break;
+	case 'feedbin':
+		url = new URL('https://feedbin.com/');
+		url.searchParams.set('subscribe', feed);
+		break;
 	case 'inoreader':
 		url = new URL('https://www.inoreader.com');
 		url.searchParams.set('add_feed', feed);

--- a/options.html
+++ b/options.html
@@ -39,6 +39,13 @@
 					</svg>
 					<span>Feedly</span>
 				</label>
+				<input type="radio" name="service" value="feedbin" id="subscribe-feedbin" />
+				<label for="subscribe-feedbin" class="browser-style-label" title="Subscribe using Feedbin" data-locale-title="feedbinSubscribe">
+					<svg class="icon" width="60" height="32">
+						<use xlink:href="icons.svg#feedbin" />
+					</svg>
+					<span>Feedbin</span>
+				</label>
 				<input type="radio" name="service" id="subscribe-inoreader" value="inoreader" />
 				<label for="subscribe-inoreader" class="browser-style-label" title="Subscribe using Inoreader" data-locale-title="inoreaderSubscribe">
 					<svg class="icon" width="32" height="32">


### PR DESCRIPTION
Adds support for subscribing via [Feedbin](https://feedbin.com)  

[Feedbin documentation for subscription URL](https://feedbin.com/help/how-to-subscribe/#url)  

Depends on [logos #27](https://github.com/shgysk8zer0/logos/pull/27)